### PR TITLE
term_standardizer and term_standardizer_spec

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -7,9 +7,9 @@
 name: "Ruby on Rails CI"
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.16.0)
       execjs (~> 2)
-    avo (3.8.1)
+    avo (3.9.1)
       actionview (>= 6.1)
       active_link_to
       activerecord (>= 6.1)
@@ -137,7 +137,7 @@ GEM
       faraday-multipart (~> 1.0, >= 1.0.4)
     code_analyzer (0.5.5)
       sexp_processor
-    concurrent-ruby (1.3.2)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal
@@ -200,11 +200,15 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
     ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux-musl)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     flipper (1.3.0)
       concurrent-ruby (< 2)
     flipper-active_record (1.3.0)
@@ -314,8 +318,8 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (8.4.4)
-    parallel (1.24.0)
-    parser (3.3.2.0)
+    parallel (1.25.1)
+    parser (3.3.3.0)
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
@@ -396,8 +400,8 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.0)
+      strscan
     rouge (4.2.1)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
@@ -429,10 +433,6 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.31.3)
       parser (>= 3.3.1.0)
-    rubocop-capybara (2.20.0)
-      rubocop (~> 1.41)
-    rubocop-factory_bot (2.26.0)
-      rubocop (~> 1.41)
     rubocop-performance (1.21.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
@@ -441,16 +441,11 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rspec (2.31.0)
-      rubocop (~> 1.40)
-      rubocop-capybara (~> 2.17)
-      rubocop-factory_bot (~> 2.22)
-      rubocop-rspec_rails (~> 2.28)
-    rubocop-rspec_rails (2.29.0)
-      rubocop (~> 1.40)
+    rubocop-rspec (3.0.1)
+      rubocop (~> 1.61)
     ruby-graphviz (1.2.5)
       rexml
-    ruby-openai (7.0.1)
+    ruby-openai (7.1.0)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
@@ -525,7 +520,7 @@ GEM
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
-    turbo_power (0.6.1)
+    turbo_power (0.6.2)
       turbo-rails (>= 1.3.0)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
@@ -563,11 +558,19 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
   arm-linux
+  arm-linux-gnu
+  arm-linux-musl
   arm64-darwin
   x86-linux
+  x86-linux-gnu
+  x86-linux-musl
   x86_64-darwin
   x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   autoprefixer-rails

--- a/app/helpers/application_template_helper.rb
+++ b/app/helpers/application_template_helper.rb
@@ -36,7 +36,7 @@ module ApplicationTemplateHelper
     "#{base_klasses} #{is_link_active?(url:) ? active_klasses : inactive_classes}"
   end
 
-  def is_link_active?(url:)
+  def link_active?(url:)
     (request.path.start_with?(url) && url != "/") || request.path == url
   end
 end

--- a/app/models/concerns/ats/greenhouse/job_details.rb
+++ b/app/models/concerns/ats/greenhouse/job_details.rb
@@ -42,22 +42,10 @@ module Ats
 
       def fetch_employment_type(data)
         default = 'Full-time'
-        keywords = {
-          /intern/i => 'Internship',
-          /\bco-op\b/i => 'Internship',
-          /full[- ]?time/i => 'Full-time',
-          /part[- ]?time/i => 'Part-time',
-          /unlimited contract/i => 'Permanent',
-          /contract/i => 'Contract',
-          /regular/i => 'Full-time',
-          /permanent/i => 'Permanent'
-        }
 
         employment_type_custom_field = data['metadata']&.find { |field| field['name'] == "Employment Type" }
         string = employment_type_custom_field&.dig('value')
-        return default unless string
-
-        keywords.find { |k, v| break v if string.match?(k) } || default
+        return string || default
       end
 
       def fetch_salary(data)

--- a/app/services/category_sidebar.rb
+++ b/app/services/category_sidebar.rb
@@ -50,7 +50,7 @@ class CategorySidebar
 
       ['checkbox', seniority, seniority_id, count, params]
     end.compact
-    @resources['seniority'] = sort_by_count_desc(results)
+    @resources['seniority'] = results
   end
 
   def build_location_array

--- a/app/services/standardizer/job_standardizer.rb
+++ b/app/services/standardizer/job_standardizer.rb
@@ -5,6 +5,7 @@ module Standardizer
     end
 
     def standardize
+      Standardizer::TermStandardizer.new(@job).standardize
       Standardizer::RoleStandardizer.new(@job).standardize
       Standardizer::SeniorityStandardizer.new(@job).standardize
       Standardizer::LocationStandardizer.new(@job).standardize

--- a/app/services/standardizer/term_standardizer.rb
+++ b/app/services/standardizer/term_standardizer.rb
@@ -1,0 +1,41 @@
+module Standardizer
+  class TermStandardizer
+    def initialize(job = nil)
+      @job = job
+      @map = YAML.load_file(Rails.root.join('config', 'term_mapping.yml'))['regex'].with_indifferent_access
+    end
+
+    def standardize
+      categories = %i[employment_type seniority]
+
+      categories.each do |category|
+        term = @job.send(category)
+        replacement = standardize_term(term, category)
+        @job.update_attribute(category, replacement) unless term == replacement
+      end
+    end
+
+    def standardize_term(term, category)
+      return unless term && category
+
+      keywords = @map[category]
+      match = keywords.find do |k, v|
+        exp = Regexp.new(k, Regexp::IGNORECASE)
+        break v if term.match?(exp)
+      end
+      match || term
+    end
+
+    private
+
+    def fetch_all(categories)
+      default_map = {}
+
+      categories.each_value do |sub_mappings|
+        default_map.merge!(sub_mappings)
+      end
+
+      default_map
+    end
+  end
+end

--- a/config/term_mapping.yml
+++ b/config/term_mapping.yml
@@ -1,0 +1,25 @@
+# The expressions in each category are ordered in descending order of priority
+# (e.g., part-time precedes employee so that 'Part-time-employee' maps to 'Part-time')
+regex:
+  employment_type:
+    intern(?!ational): Internship
+    \bco-op\b: Internship
+    fixed[- _]?term: Contract
+    unlimited contract: Permanent
+    contract: Contract
+    consultant: Contract
+    full[- _]?time: Full-time
+    part[- _]?time: Part-time
+    permanent: Permanent
+    regular: Full-time
+    employee: Contract
+  seniority:
+    intern(?!ational): Internship
+    entry[- _]?level: Entry-Level
+    mid[- _]?level: Mid-Level
+    senior: Senior
+    experienced: Senior
+    ([^a-z])lead\b: Senior
+    manager: Senior
+    supervisor: Senior
+    associate: Junior

--- a/lib/builders/ats_builder.rb
+++ b/lib/builders/ats_builder.rb
@@ -1,6 +1,3 @@
-require 'CSV'
-# What needs to be autoloaded so that we don't need to require standard libraries here?
-
 module Builders
   class AtsBuilder
     attr_reader :ats_csv

--- a/lib/builders/ats_builder.rb
+++ b/lib/builders/ats_builder.rb
@@ -1,3 +1,6 @@
+require 'CSV'
+# What needs to be autoloaded so that we don't need to require standard libraries here?
+
 module Builders
   class AtsBuilder
     attr_reader :ats_csv

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,7 +38,8 @@ module Constants
       'Full-time',
       'Permanent',
       'Contract',
-      'Part-time'
+      'Part-time',
+      'Internship'
     ].freeze
 
     CONVERT_TO_DAYS = {

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 require Rails.root.join('spec', 'support', 'spec_constants.rb')
 
 RSpec.describe Company do

--- a/spec/services/term_standardizer_spec.rb
+++ b/spec/services/term_standardizer_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+require Rails.root.join('spec', 'support', 'spec_constants.rb')
+
+RSpec.describe Standardizer::TermStandardizer do
+  describe '#standardize_term' do
+    before do
+      @standardizer = Standardizer::TermStandardizer.new
+    end
+
+    it 'returns nil when a term does not exist' do
+      first_term = @standardizer.standardize_term(nil, :employment_type)
+      second_term = @standardizer.standardize_term(nil, :seniority)
+
+      expect(first_term).to be_nil
+      expect(second_term).to be_nil
+    end
+
+    it 'returns a nonstandard term unchanged if no suitable replacement is found' do
+      first_term = @standardizer.standardize_term('foo_bar', :employment_type)
+      second_term = @standardizer.standardize_term('gobbledy-gook', :seniority)
+
+      expect(first_term).to eq('foo_bar')
+      expect(second_term).to eq('gobbledy-gook')
+    end
+
+    context 'With nonstandard seniority descriptors:' do
+      terms = {
+        'intern' => 'Internship',
+        'midlevel' => 'Mid-Level',
+        'Experienced' => 'Senior',
+        'Manager/Supervisor' => 'Senior',
+        'Team_lead' => 'Senior',
+        'International Manager' => 'Senior'
+      }
+
+      terms.each do |term, standard_term|
+        it "returns #{standard_term} in place of #{term}" do
+          result = @standardizer.standardize_term(term, :seniority)
+          expect(result).to eq(standard_term)
+        end
+      end
+    end
+
+    context 'With nonstandard employment_types:' do
+      terms = {
+        'fulltime' => 'Full-time',
+        'Permanent full-time employee' => 'Full-time',
+        'Global Core Team Contract' => 'Contract',
+        'Fixed Term' => 'Contract',
+        'Fixed-term fulltime employee' => 'Contract',
+        'Part-time contract' => 'Contract'
+      }
+
+      terms.each do |term, standard_term|
+        it "returns #{standard_term} in place of #{term}" do
+          result = @standardizer.standardize_term(term, :employment_type)
+          expect(result).to eq(standard_term)
+        end
+      end
+    end
+  end
+  describe '#standardize' do
+    it 'replaces a nonstandard seniority descriptor with its standard equivalent' do
+      job = create(:job, seniority: 'junior associate')
+      Standardizer::TermStandardizer.new(job).standardize
+      expect(job.seniority).to eq('Junior')
+    end
+    it 'replaces a nonstandard employment_type with its standard equivalent' do
+      job = create(:job, employment_type: 'Global Core Team Contract')
+      Standardizer::TermStandardizer.new(job).standardize
+      expect(job.employment_type).to eq('Contract')
+    end
+  end
+end


### PR DESCRIPTION
Adds an additional standardizer for JobStandardizer to run before the others. (This seems to be the simplest, least-effort way to fix the problem of non-standard terms, although it does mean that jobs are first created to db, then standardized).

Uses a yaml file of regular expressions to consolidate all known or predicted non-standard terms in the seniority and employment_type categories, regardless of which ATS they originate from. Specifying the ATS would only matter if we wanted to map certain ATSs differently, which I don't think we currently have any reason to do.