### PR TITLE
Added rake task for importer xml workable

### DIFF
--- a/app/jobs/importer/xml/workable_job.rb
+++ b/app/jobs/importer/xml/workable_job.rb
@@ -2,10 +2,13 @@ module Importer
   module Xml
     class WorkableJob < ApplicationJob
       queue_as :default
-      retry_on StandardError, attempts: 0
+      retry_on StandardError, attempts: 5
 
       def perform
         Importer::Xml::Workable.new.import_xml
+      rescue => e
+        puts "Job failed with error: #{e.class.name}: #{e.message}. Retrying..."
+        raise e
       end
     end
   end

--- a/app/services/importer/xml/workable.rb
+++ b/app/services/importer/xml/workable.rb
@@ -7,6 +7,7 @@ module Importer
     # In order to handle this, we create a variable with all the job_posting_urls from the XML feed
     # We then resolve the redirect to get the final url and build the company / job posting from the API via CreateJobFromUrl, this bypasses rate limiting problems and uses standard functionality
     class Workable < ApplicationService
+      include FaradayHelpers
       # TODO: Fix this as only capturing a portion of the redirect urls at the moment. There is a wait screen page that is sometimes coming up and it may require a proxy to process. Check for the interim response code. Setup a proxy and use a different IP address to check the page.
       # TODO: Add count for number of urls in XML feed and number of urls processed so that we can evaluate success rate
 

--- a/lib/tasks/xml_importer.rake
+++ b/lib/tasks/xml_importer.rake
@@ -1,0 +1,7 @@
+namespace :xml do
+  desc "Import jobs from Workable XML feed"
+  task workable: :environment do
+    puts "Import jobs from Workable XML feed : Started"
+    Importer::Xml::WorkableJob.new.perform
+  end
+end


### PR DESCRIPTION
- Issue addressed : https://github.com/Ches-ctrl/Cheddar/issues/200
# Added rake task to use `rake xml:workable` to import all the jobs from the XML feed.